### PR TITLE
Agptek Rocker: Fix bootloader build command

### DIFF
--- a/tools/agptek_rocker/README
+++ b/tools/agptek_rocker/README
@@ -18,16 +18,16 @@ docker build . -t "agptek-dev"
 
 Then you can start container and work with update.upt.
 If you want to generate patched update image in automatic way:
-docker run --rm -it agptek-dev -v /path/to/dir/with/update.upt:/upt \
--e UPT_DIR=/upt bootloader_install.sh
+docker run --rm -it -v /path/to/dir/with/update.upt:/upt \
+-e UPT_DIR=/upt agptek-dev bootloader_install.sh
 
 Patched update.upt with rockbox bootloader and rockbox.zip should end up in
 specified directory.
 
 If you want to play around, hack something etc. you can run container in
 interactive mode:
-docker run -it agptek-dev -v /path/to/dir/with/update.upt:/upt \
--e UPT_DIR=/upt bash
+docker run -it -v /path/to/dir/with/update.upt:/upt \
+-e UPT_DIR=/upt agptek-dev bash
 
 
 Files in this directory:


### PR DESCRIPTION
The current build command errors out in the latest version of docker (in my case, `Docker version 17.12.0-ce, build c97c6d6`). The problem seems that the container tag should be at the end of the command right before the command to be run.